### PR TITLE
Disable updating major versions of indirect dependencies.

### DIFF
--- a/default.json
+++ b/default.json
@@ -23,6 +23,12 @@
 			"enabled": true
 		},
 		{
+			"matchManagers": ["gomod"],
+			"matchDepTypes": ["indirect"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
+		},
+		{
 			"matchManagers": ["nodenv"],
 			"matchPackageNames": ["node"],
 			"matchUpdateTypes": ["major"],


### PR DESCRIPTION
We don't want to upgrade major indirect dependencies because they are effectively different modules entirely. It is up to the dependency what its dependencies are.