### PR TITLE
Don't upgrade indirect v0 dependencies.

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,6 +29,12 @@
 			"enabled": false
 		},
 		{
+			"matchManagers": ["gomod"],
+			"matchDepTypes": ["indirect"],
+			"matchCurrentVersion": "^v0\\..*",
+			"enabled": false
+		},
+		{
 			"matchManagers": ["nodenv"],
 			"matchPackageNames": ["node"],
 			"matchUpdateTypes": ["major"],


### PR DESCRIPTION
This hopefully prevents constant compatibility breaking in indirect dependencies that are not stable.